### PR TITLE
Add sendmailmp3 script to allow voicemail attachments as MP3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,15 @@ RUN apt-get update \
         libjansson-dev \
         libssl-dev \
         curl \
-        msmtp
+        msmtp \
+	dos2unix \
+	lame
 
 # Asterisk expects /usr/sbin/sendmail
 RUN ln -s /usr/bin/msmtp /usr/sbin/sendmail
+
+COPY sendmailmp3 /usr/sbin/sendmailmp3
+RUN chmod 755 /usr/sbin/sendmailmp3
 
 ENV SRTP_VERSION 1.4.4
 RUN cd /tmp \

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,17 @@ You can create a configuration file for msmtp like the following.::
     user pbx@your.domain
     password yoursecretpassword
 
+Voicemail
+=========
+
+This image also includes the voicemail MP3 conversion script from https://gist.github.com/dougbtv/3d820a597347396a6e8d
+
+To attach voicemails as MP3 files, make the following changes to your voicemail.conf:
+
+    format=wav
+    mailcmd=/usr/sbin/sendmailmp3
+
+
 Customization
 =============
 

--- a/sendmailmp3
+++ b/sendmailmp3
@@ -1,0 +1,95 @@
+#! /bin/sh 
+# Asterisk voicemail attachment conversion script 
+# Revision history :
+# 22/11/2010 - V1.0 - Creation by N. Bernaerts
+# 07/02/2012 - V1.1 - Add handling of mails without attachment (thanks to Paul Thompson)
+# 01/05/2012 - V1.2 - Use mktemp, pushd & popd
+# 08/05/2012 - V1.3 - Change mp3 compression to CBR to solve some smartphone compatibility (thanks to Luca Mancino)
+# 01/08/2012 - V1.4 - Add PATH definition to avoid any problem (thanks to Christopher Wolff)
+
+# set PATH
+PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+# save the current directory 
+pushd .
+ 
+# create a temporary directory and cd to it 
+TMPDIR=$(mktemp -d)
+cd $TMPDIR 
+ 
+# dump the stream to a temporary file 
+cat >> stream.org 
+ 
+# get the boundary 
+BOUNDARY=`grep "boundary=" stream.org | cut -d'"' -f 2` 
+ 
+# cut the file into parts 
+# stream.part - header before the boundary 
+# stream.part1 - header after the bounday 
+# stream.part2 - body of the message 
+# stream.part3 - attachment in base64 (WAV file) 
+# stream.part4 - footer of the message 
+awk '/'$BOUNDARY'/{i++}{print > "stream.part"i}' stream.org 
+ 
+# if mail is having no audio attachment (plain text) 
+PLAINTEXT=`cat stream.part1 | grep 'plain'` 
+if [ "$PLAINTEXT" != "" ] 
+then 
+ 
+  # prepare to send the original stream 
+  cat stream.org > stream.new 
+ 
+# else, if mail is having audio attachment 
+else 
+ 
+  # cut the attachment into parts 
+  # stream.part3.head - header of attachment 
+  # stream.part3.wav.base64 - wav file of attachment (encoded base64) 
+  sed '7,$d' stream.part3 > stream.part3.wav.head 
+  sed '1,6d' stream.part3 > stream.part3.wav.base64 
+ 
+  # convert the base64 file to a wav file 
+  dos2unix -o stream.part3.wav.base64 
+  base64 -di stream.part3.wav.base64 > stream.part3.wav 
+ 
+  # convert wav file to mp3 file
+  # -b 24 is using CBR, giving better compatibility on smartphones (you can use -b 32 to increase quality)
+  # -V 2 is using VBR, a good compromise between quality and size for voice audio files
+  lame -m m -b 24 stream.part3.wav stream.part3.mp3
+ 
+  # convert back mp3 to base64 file 
+  base64 stream.part3.mp3 > stream.part3.mp3.base64 
+ 
+  # generate the new mp3 attachment header 
+  # change Type: audio/x-wav to Type: audio/mpeg 
+  # change name="msg----.wav" to name="msg----.mp3" 
+  sed 's/x-wav/mpeg/g' stream.part3.wav.head | sed 's/.wav/.mp3/g' > stream.part3.mp3.head 
+ 
+  # generate first part of mail body, converting it to LF only 
+  mv stream.part stream.new 
+  cat stream.part1 >> stream.new 
+  cat stream.part2 >> stream.new 
+  cat stream.part3.mp3.head >> stream.new 
+  dos2unix -o stream.new 
+ 
+  # append base64 mp3 to mail body, keeping CRLF 
+  unix2dos -o stream.part3.mp3.base64 
+  cat stream.part3.mp3.base64 >> stream.new 
+ 
+  # append end of mail body, converting it to LF only 
+  echo "" >> stream.tmp 
+  echo "" >> stream.tmp 
+  cat stream.part4 >> stream.tmp 
+  dos2unix -o stream.tmp 
+  cat stream.tmp >> stream.new 
+ 
+fi 
+ 
+# send the mail thru sendmail 
+cat stream.new | sendmail -t 
+ 
+# go back to original directory 
+popd
+ 
+# remove all temporary files and temporary directory 
+rm -Rf $TMPDIR


### PR DESCRIPTION
Hi - great image.  This PR just adds the sendmailmp3 script from https://gist.github.com/dougbtv/3d820a597347396a6e8d so that voicemails can be attached to email as mp3 format instead of wav.

To support this, I'm also adding the dos2unix and lame packages.  I also added a section to the readme to detail the config changes needed.
